### PR TITLE
「hidari 🥺」と入力するとロストした画像マークが表示される。_#14

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:dev": "tsc -b && vite build --mode development",
+    "build:production": "tsc -b && vite build --mode production",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -177,6 +177,8 @@ function App() {
           name: "Kappa",
           startIndex: 24,
           endIndex: 28,
+          imageUrl: "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/3.0",
+          type: "Twitch"
       }] });
 
       addComment({ 

--- a/src/hooks/useStreamerbot.ts
+++ b/src/hooks/useStreamerbot.ts
@@ -7,11 +7,24 @@ import { useState, useEffect, useRef } from 'react';
 type ConnectionStatus = 'connecting' | 'connected' | 'disconnected' | 'error';
 
 /**
+ * エモートの型定義
+ */
+export type Emote = {
+    id?: string;
+    endIndex: number;
+    imageUrl: string;
+    name: string;
+    startIndex: number;
+    zeroWidth?: boolean;
+    type: string;
+}
+
+/**
  * メッセージの型定義
  */
 export type Message = {
     text: string;
-    emotes: any[];
+    emotes: Emote[];
 }
 
 /**
@@ -33,6 +46,10 @@ type UseStreamerBotOptions = {
 function getMessage({ data }: { data: any }): Message {
     const message = data?.message?.message || '';
     const emotes = data?.message?.emotes || [];
+
+    if (import.meta.env.MODE === 'development') {
+        console.log('Received message data:', data);
+    }
 
     return {
         text: message || '',
@@ -86,21 +103,35 @@ export function useStreamerBot({
             if (data.arguments.isTest) {
                 if (data.arguments.triggerName === "Test" &&
                     data.arguments.triggerCategory === "Core") {
-                    handleComment({
-                        data: {
-                            message: { 
-                                message: "Kappa" + "これはU+2003エモートテストです。",
-                                emotes: [
-                                    {
-                                        id: "25",
-                                        name: "Kappa",
-                                        startIndex: 0,
-                                        endIndex: 4,
-                                    }
-                                ]
+                        const regex = /comment/i;
+                        for (let key in data.arguments) {
+                            if (regex.test(key.toString())) {
+                                handleComment({
+                                    data: {
+                                        message: {
+                                            message: data.arguments[key],
+                                            emotes: []
+                                        },
+                                    },
+                                });
+                            }
+                        }
+                    
+                        handleComment({
+                            data: {
+                                message: { 
+                                    message: "Kappa" + "これはU+2003エモートテストです。",
+                                    emotes: [
+                                        {
+                                            id: "25",
+                                            name: "Kappa",
+                                            startIndex: 0,
+                                            endIndex: 4,
+                                        }
+                                    ]
+                                },
                             },
-                        },
-                    });
+                        });
                 }
             }
         });

--- a/src/hooks/useStreamerbot.ts
+++ b/src/hooks/useStreamerbot.ts
@@ -127,6 +127,8 @@ export function useStreamerBot({
                                             name: "Kappa",
                                             startIndex: 0,
                                             endIndex: 4,
+                                            imageUrl: "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/3.0",
+                                            type: "Twitch"
                                         }
                                     ]
                                 },

--- a/src/hooks/useTwitchEmotes.ts
+++ b/src/hooks/useTwitchEmotes.ts
@@ -192,20 +192,6 @@ function renderNativeTwitchEmotes(
 }
 
 /**
- * URLが有効かどうかを検証する関数
- * @param url - 検証するURL文字列
- * @returns URLが有効な場合はtrue、そうでない場合はfalse
- */
-function isValidUrl(url: string): boolean {
-    try {
-        new URL(url);
-        return true;
-    } catch {
-        return false;
-    }
-}
-
-/**
  * Twitchのメッセージテキストを外部エモートのみでレンダリングする関数
  * @param text - メッセージテキスト
  * @param externalEmotes - 外部エモートのマップ
@@ -219,9 +205,6 @@ function renderExternalEmotesOnly(
 ): React.ReactNode[] {
     const parts = text.split(/\s+/);
 
-    // ue ☺
-    // endIndex: 4
-    // startIndex: 3
     return parts.map((part, index) => {
         const custom = customStamps.get(part);
         if (custom) {
@@ -272,8 +255,8 @@ function renderExternalEmotesOnly(
                 }, part)];
             }
         } else {
-            if (isValidUrl(emote.url)) {
-                return React.createElement('img', {
+            return index < parts.length - 1 
+                ? [React.createElement('img', {
                     key: `${emote.name}-${index}`,
                     src: emote.url,
                     alt: emote.name,
@@ -282,12 +265,17 @@ function renderExternalEmotesOnly(
                         objectFit: "cover",
                         maxHeight: "52px"
                     }
-                });
-            } else {
-                return [React.createElement("div", 
-                    { key: `text-${index}` 
-                }, part)];
-            }
+                }), ' ']
+                : [React.createElement('img', {
+                    key: `${emote.name}-${index}`,
+                    src: emote.url,
+                    alt: emote.name,
+                    style: {
+                        height: "100%",
+                        objectFit: "cover",
+                        maxHeight: "52px"
+                    }
+                })];
         }
     });
 }

--- a/src/hooks/useTwitchEmotes.ts
+++ b/src/hooks/useTwitchEmotes.ts
@@ -172,7 +172,7 @@ function renderNativeTwitchEmotes(
         result.push(
             React.createElement('img', {
                 key: `${emote.id}-${start}`,
-                src: `https://static-cdn.jtvnw.net/emoticons/v2/${emote.id}/default/dark/3.0`,
+                src: emote.imageUrl,
                 style: {
                     height: "100%",
                     objectFit: "cover",
@@ -192,6 +192,20 @@ function renderNativeTwitchEmotes(
 }
 
 /**
+ * URLが有効かどうかを検証する関数
+ * @param url - 検証するURL文字列
+ * @returns URLが有効な場合はtrue、そうでない場合はfalse
+ */
+function isValidUrl(url: string): boolean {
+    try {
+        new URL(url);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
  * Twitchのメッセージテキストを外部エモートのみでレンダリングする関数
  * @param text - メッセージテキスト
  * @param externalEmotes - 外部エモートのマップ
@@ -205,6 +219,9 @@ function renderExternalEmotesOnly(
 ): React.ReactNode[] {
     const parts = text.split(/\s+/);
 
+    // ue ☺
+    // endIndex: 4
+    // startIndex: 3
     return parts.map((part, index) => {
         const custom = customStamps.get(part);
         if (custom) {
@@ -227,7 +244,7 @@ function renderExternalEmotesOnly(
         const emote = externalEmotes.get(part);
 
         if (!emote) {
-            if (part.includes("U+2003")){
+            if (part.includes("U+2003")) {
                 const subParts = part.split("U+2003");
 
                 return React.createElement("div",
@@ -249,34 +266,29 @@ function renderExternalEmotesOnly(
                     ))
                 );
             }
-            else{
+            else {
+                return [React.createElement("div", 
+                    { key: `text-${index}` 
+                }, part)];
+            }
+        } else {
+            if (isValidUrl(emote.url)) {
+                return React.createElement('img', {
+                    key: `${emote.name}-${index}`,
+                    src: emote.url,
+                    alt: emote.name,
+                    style: {
+                        height: "100%",
+                        objectFit: "cover",
+                        maxHeight: "52px"
+                    }
+                });
+            } else {
                 return [React.createElement("div", 
                     { key: `text-${index}` 
                 }, part)];
             }
         }
-
-        return index < parts.length - 1 
-            ? [React.createElement('img', {
-                key: `${emote.name}-${index}`,
-                src: emote.url,
-                alt: emote.name,
-                style: {
-                    height: "100%",
-                    objectFit: "cover",
-                    maxHeight: "52px"
-                }
-            }), ' ']
-            : [React.createElement('img', {
-                key: `${emote.name}-${index}`,
-                src: emote.url,
-                alt: emote.name,
-                style: {
-                    height: "100%",
-                    objectFit: "cover",
-                    maxHeight: "52px"
-                }
-            })];
     });
 }
 

--- a/src/hooks/useTwitchEmotes.ts
+++ b/src/hooks/useTwitchEmotes.ts
@@ -252,7 +252,7 @@ function renderExternalEmotesOnly(
             else {
                 return [React.createElement("div", 
                     { key: `text-${index}` 
-                }, part)];
+                }, part + (index < parts.length - 1 ? ' ' : ''))];
             }
         } else {
             return index < parts.length - 1 

--- a/src/hooks/useTwitchEmotes.ts
+++ b/src/hooks/useTwitchEmotes.ts
@@ -244,7 +244,7 @@ function renderExternalEmotesOnly(
                     subParts.map((subPart, subIndex) => (
                         React.createElement("span",
                             { key: `text-${index}-${subIndex}` },
-                            subPart
+                            subPart + (subIndex < subParts.length - 1 ? ' ' : '')
                         )
                     ))
                 );


### PR DESCRIPTION
# イシュー番号

- #14 
- #1 

# 何をしたか

- twitchのエモートのURLが固定になっていた問題を修正しました。
- その他修正
  - デバッグビルドと本番ビルドコマンドを追加しました
  - クリックテストによるコマンドを一部修正しました。
  - emote型を定義しました。

# 備考

- 一旦 #1 も関連とみなし、修正したものとしてクローズします。

close #14 
close #1