### PR TITLE
「✨」で[x]が表示される #22

### DIFF
--- a/packages/twitch-text-flow-overlay/src/hooks/useTwitchEmotes.tsx
+++ b/packages/twitch-text-flow-overlay/src/hooks/useTwitchEmotes.tsx
@@ -161,12 +161,20 @@ function renderLine(
         // Twitch エモート
         const twitch = twitchEmotes.find(e => line.slice(e.startIndex, e.endIndex + 1) === part);
         if (twitch) {
-            nodes.push(
-                <img
-                    key={`twitch-${twitch.id}-${part}-${index}`}
-                    src={twitch.imageUrl}
-                />
-            );
+            if (twitch.imageUrl.includes("twemoji")) {
+                nodes.push(
+                    <span key={`twitch-${twitch.id}-${part}-${index}`}>
+                        {part}
+                    </span>
+                );
+            } else {
+                nodes.push(
+                    <img
+                        key={`twitch-${twitch.id}-${part}-${index}`}
+                        src={twitch.imageUrl}
+                    />
+                );
+            }
             continue;
         }
 


### PR DESCRIPTION
## イシュー番号

- #22

## 何をしましたか

- Twemoji の場合に画像ではなく通常の絵文字を表示するようにしました。これによりImageUrlが不正な値を返してきても表示することができます。

close #22 