### PR TITLE
U+2003 + スタンプで表示がおかしくなる #23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+index.html
 
 # Editor directories and files
 .vscode/*

--- a/packages/twitch-text-flow-overlay/src/hooks/useTwitchEmotes.tsx
+++ b/packages/twitch-text-flow-overlay/src/hooks/useTwitchEmotes.tsx
@@ -133,7 +133,7 @@ function renderLine(
     const nodes: React.ReactNode[] = [];
 
     for (const [index, part] of parts.entries()) {
-        if (part.trim() === "") {
+        if (part === " ") {
             nodes.push(<span key={`space-${index}`}> </span>);
             continue;
         }

--- a/packages/twitch-text-flow-overlay/src/hooks/useTwitchEmotes.tsx
+++ b/packages/twitch-text-flow-overlay/src/hooks/useTwitchEmotes.tsx
@@ -133,6 +133,10 @@ function renderLine(
     const nodes: React.ReactNode[] = [];
 
     for (const [index, part] of parts.entries()) {
+        if (part.trim() === "") {
+            continue;
+        }
+
         // カスタムスタンプ
         const custom = customStamps.get(part);
         if (custom) {
@@ -159,7 +163,7 @@ function renderLine(
         }
 
         // Twitch エモート
-        const twitch = twitchEmotes.find(e => line.slice(e.startIndex, e.endIndex + 1) === part);
+        const twitch = twitchEmotes.find(e => e.name === part);
         if (twitch) {
             if (twitch.imageUrl.includes("twemoji")) {
                 nodes.push(

--- a/packages/twitch-text-flow-overlay/src/hooks/useTwitchEmotes.tsx
+++ b/packages/twitch-text-flow-overlay/src/hooks/useTwitchEmotes.tsx
@@ -133,11 +133,6 @@ function renderLine(
     const nodes: React.ReactNode[] = [];
 
     for (const [index, part] of parts.entries()) {
-        if (part === " ") {
-            nodes.push(<span key={`space-${index}`}> </span>);
-            continue;
-        }
-
         // カスタムスタンプ
         const custom = customStamps.get(part);
         if (custom) {

--- a/packages/twitch-text-flow-overlay/src/hooks/useTwitchEmotes.tsx
+++ b/packages/twitch-text-flow-overlay/src/hooks/useTwitchEmotes.tsx
@@ -134,6 +134,7 @@ function renderLine(
 
     for (const [index, part] of parts.entries()) {
         if (part.trim() === "") {
+            nodes.push(<span key={`space-${index}`}> </span>);
             continue;
         }
 


### PR DESCRIPTION
## イシュー番号

- #23 


## 何をしましたか？ 

- twitchスタンプの検索をインデックスから名前に変更しました。これによりインデックスのずれによる取得ミスがなくなります。
- その他修正
  - gitignoreにreact-cosmosのindex.htmlを含めないようにしました。

close #23 